### PR TITLE
Update column name in mrt_order_daily_report

### DIFF
--- a/models/mart/mrt_order_daily_report.sql
+++ b/models/mart/mrt_order_daily_report.sql
@@ -1,4 +1,4 @@
-SELECT DATE_TRUNC(order_created_at, DAY) AS report_date,
+SELECT DATE_TRUNC(order_created_at, DAY) AS reporting_date,
     mapping.account_manager,
     mapping.state,
     COUNT(DISTINCT order_id) AS total_orders,


### PR DESCRIPTION
In thi Pull request we are renaming the "`report_date`" column to "`reporting_date`" in the `mrt_order_daily_report `model.